### PR TITLE
Fix alignment and add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # TOC-Anchor
 Automatically adds anchors to elements.
+
+## Installation
+
+```sh
+npm install toc-anchor
+```
+
 ## Usage
 In your project import the library:
 

--- a/example/index.html
+++ b/example/index.html
@@ -20,20 +20,6 @@
     <h2 id="aenean">Aenean ultricies <small>(hover me!)</small></h2>
 
     <p>mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui.</p>
-    What is Lorem Ipsum?
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-
-Why do we use it?
-It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).
-
-
-Where does it come from?
-Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
-
-The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
-
-Where can I get some?
-There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.
 
     <h2 data-anchor-id="donec">Donec non enim in turpis pulvinar facilisis <small>(hover me!)</small></h2>
 

--- a/example/index.html
+++ b/example/index.html
@@ -13,13 +13,27 @@
   </head>
   <body>
 
-    <h1>Pellentesque habitant</h1>
+    <h1 id="donec">Pellentesque habitant</h1>
 
     <p>Morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.</p>
 
     <h2 id="aenean">Aenean ultricies <small>(hover me!)</small></h2>
 
     <p>mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui.</p>
+    What is Lorem Ipsum?
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+
+Why do we use it?
+It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).
+
+
+Where does it come from?
+Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
+
+The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
+
+Where can I get some?
+There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.
 
     <h2 data-anchor-id="donec">Donec non enim in turpis pulvinar facilisis <small>(hover me!)</small></h2>
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 import { find, addAttrs, addClass } from 'domassist';
 
 /**
@@ -14,10 +13,21 @@ function TocAnchor(selector, anchorContent = null) {
 
   headings.forEach((heading) => {
     const link = document.createElement('a');
-    const anchor = heading.getAttribute('data-anchor-id') || heading.id || heading.textContent.trim().toLowerCase().replace(/\s+/g, '-');
+    let anchorId = heading.getAttribute('data-anchor-id') || heading.id || heading.textContent.trim().toLowerCase().replace(/\s+/g, '-');
+
+    /**
+     * Avoid Id name clashing
+     */
+    find(`#${anchorId}`).forEach((repeatedId, index) => {
+      if (repeatedId !== heading) {
+        anchorId += `-${index + 1}`;
+      }
+    });
+
+    heading.id = anchorId;
 
     addAttrs(link, {
-      href: `#${anchor}`,
+      href: `#${anchorId}`,
       title: heading.textContent,
       innerHTML: anchorContent
     });
@@ -29,6 +39,15 @@ function TocAnchor(selector, anchorContent = null) {
 
     heading.insertBefore(link, heading.firstChild);
   });
+
+  /**
+   * Scrolls to anchor on page reload
+   */
+  setTimeout(() => {
+    if (window.location.hash) {
+      window.location = window.location.hash;
+    }
+  }, 0);
 
   return headings;
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function TocAnchor(selector, anchorContent = null) {
     addClass(heading, 'toc-anchor-heading');
     addClass(link, 'toc-anchor-link');
 
-    heading.insertBefore(link);
+    heading.insertBefore(link, heading.firstChild);
   });
 
   return headings;

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function TocAnchor(selector, anchorContent = null) {
     addClass(heading, 'toc-anchor-heading');
     addClass(link, 'toc-anchor-link');
 
-    heading.appendChild(link);
+    heading.insertBefore(link);
   });
 
   return headings;

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "homepage": "https://github.com/firstandthird/toc-anchor#readme",
     "devDependencies": {
         "domassist": "^1.9.1",
-        "eslint": "^3.9.1",
-        "eslint-config-firstandthird": "3.2.0",
+        "eslint": "^4.13.1",
+        "eslint-config-firstandthird": "4.2.1",
         "eslint-plugin-compat": "^2.1.0",
-        "eslint-plugin-import": "^2.1.0",
-        "phantomjs-prebuilt": "2.1.15",
-        "scriptkit": "0.2.0",
+        "eslint-plugin-import": "^2.8.0",
+        "phantomjs-prebuilt": "2.1.16",
+        "scriptkit": "0.3.0",
         "tap-spec": "4.1.1",
         "tape-rollup": "4.6.4",
-        "tape-run": "3.0.0"
+        "tape-run": "3.0.1"
     },
     "scriptkit": {
         "files": {

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,18 @@
 
 .toc-anchor-link {
-    float: left;
-    height: 16px;
-    display: none;
-    margin-left: -18px;
-}
-.toc-anchor-link:after {
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' version='1.1' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'/%3E%3C/svg%3E");
-  display: block;
+  float: left;
+  margin-left: -18px;
+  padding-right: 2px;
 }
 
-.toc-anchor-heading:focus .toc-anchor-link,
-.toc-anchor-heading:hover .toc-anchor-link {
-    display: block;
+.toc-anchor-link::after {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' version='1.1' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'/%3E%3C/svg%3E");
+  display: block;
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.toc-anchor-heading:focus .toc-anchor-link::after,
+.toc-anchor-heading:hover .toc-anchor-link::after {
+  visibility: visible;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,13 @@
 
 .toc-anchor-link {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' version='1.1' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'/%3E%3C/svg%3E");
     float: left;
     height: 16px;
-    margin-left: -16px;
     display: none;
-    width: 16px;
+    margin-left: -18px;
+}
+.toc-anchor-link:after {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' version='1.1' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'/%3E%3C/svg%3E");
+  display: block;
 }
 
 .toc-anchor-heading:focus .toc-anchor-link,

--- a/test/toc-anchor.test.js
+++ b/test/toc-anchor.test.js
@@ -5,11 +5,12 @@ import domassist from 'domassist';
 import TocAnchor from '../index';
 import { teardown } from './setup';
 
-const setup = (total) => {
+const setup = (total, properties) => {
   const frag = document.createDocumentFragment();
-  for (let i = 0; i < total; i += 1) {
+  for (let i = 1; i <= total; i += 1) {
     const heading = document.createElement('h2');
-    heading.textContent = `Heading ${1}`;
+    heading.id = `header-${i}`;
+    heading.textContent = `Heading ${i}`;
     frag.appendChild(heading);
   }
   return frag;
@@ -57,3 +58,16 @@ test('tocAnchor - Generates anchors from Element', assert => {
   assert.end();
 });
 
+test('tocAnchor - Creates an anchor with the right hash', assert => {
+  const el = document.getElementById('toc-container').appendChild(setup(1));
+  const headings = domassist.findOne('#header-1');
+
+  TocAnchor(headings);
+
+  const anchorHash = (domassist.findOne('.toc-anchor-link').href).split('#')[1];
+
+  assert.equals(anchorHash, 'header-1', 'Anchor link matches element id');
+
+  teardown(el);
+  assert.end();
+});


### PR DESCRIPTION
This PR fixes alignment of the anchor icon on two line headings. See issue below:

<img width="80" alt="alignment-issue" src="https://user-images.githubusercontent.com/5501685/33994646-a2eb5972-e0db-11e7-8b50-ea4603491b4a.png">

As well as scrolling to anchor on page reload and also avoids hash IDs clashing.